### PR TITLE
Docs (readme): Fix full bf2 stack example coredns config invalid `hosts` ttl

### DIFF
--- a/docs/full-bf2-stack-example/config/coredns/Corefile
+++ b/docs/full-bf2-stack-example/config/coredns/Corefile
@@ -2,7 +2,7 @@
 .:53 {
     # Try resolving DNS using the hosts file first
     hosts /hosts {
-        ttl 1s     # DNS TTL. 1 second so that the BF2 client doesn't cache the DNS
+        ttl 1       # DNS TTL. 1 second so that the BF2 client doesn't cache the DNS
         no_reverse  # Do not generate reverse DNS records
         reload 5s   # hosts file reload interval
         fallthrough # If no host is matched, continue down the plugin chain


### PR DESCRIPTION
Fixes bug in #40