### PR TITLE
Docs: Add `asp.example.com` alias for `asp-nginx` service in full br2 stack example

### DIFF
--- a/docs/full-bf2-stack-example/docker-compose.yml
+++ b/docs/full-bf2-stack-example/docker-compose.yml
@@ -175,8 +175,10 @@ services:
     # volumes:
     #   - ./config/ASP/nginx/nginx.conf:/etc/nginx/nginx.conf:ro # Customize only if needed
     networks:
-      - traefik-network
-      - bf2-network
+      traefik-network:
+      bf2-network:
+        aliases:
+          - asp.example.com
     depends_on:
       - init-container
       - asp-php


### PR DESCRIPTION
This enables `asp-php` to resolve `asp.example.com` DNS to `asp-nginx` container IP to enable the `ASP` `Testconfig` and `Importlogs` modules to work correctly without FQDN DNS resolution (important for this example to work correctly).