### PR TITLE
Fix (ASP): Turn off chunked transfer encoding for `.aspx` in `asp-nginx` `nginx.conf`

### DIFF
--- a/config/ASP/nginx/nginx.conf
+++ b/config/ASP/nginx/nginx.conf
@@ -77,7 +77,26 @@ http {
         }
 
         # Pass .aspx to php
-        location ~ \.aspx|\.php$ {
+        location ~ \.aspx$ {
+            # Check that the PHP script exists before passing it
+            try_files $fastcgi_script_name =404;
+
+            # Turn off chunked transfer encoding in HTTP/1.1. Older BF2 client or server python files may not be able to handle it
+            chunked_transfer_encoding off;
+
+            # Disable fastcgi output buffering
+            fastcgi_buffering off;
+
+            # Set fastcgi max execution response time
+            fastcgi_read_timeout 10s;
+            fastcgi_split_path_info ^(.+\.aspx)(/.+)$;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_index index.aspx;
+            fastcgi_pass asp-php:9000;
+        }
+
+        location ~ \.php$ {
             # Check that the PHP script exists before passing it
             try_files $fastcgi_script_name =404;
 

--- a/docs/full-bf2-stack-example/config/ASP/nginx/nginx.conf
+++ b/docs/full-bf2-stack-example/config/ASP/nginx/nginx.conf
@@ -56,6 +56,11 @@ http {
         # whether they exist or not. So quit right here, and allow direct access
         # to common format files. Add formats here to allow direct link access
         location ~ \.(gif|png|jpe?g|bmp|css|js|swf|wav|avi|mpg|ttf|woff|ico)$ {
+            # Show empty flag
+            location ~ (/ASP/frontend/images/flags)/.*\.(png|jpeg|jpg|gif)$ {
+                add_header Cache-Control "public, s-maxage=600, maxage=600";
+                try_files $uri $1/xx.png =404;
+            }
             add_header Cache-Control "public, s-maxage=600, maxage=600";
             try_files $uri =404;
         }
@@ -72,7 +77,26 @@ http {
         }
 
         # Pass .aspx to php
-        location ~ \.aspx|\.php$ {
+        location ~ \.aspx$ {
+            # Check that the PHP script exists before passing it
+            try_files $fastcgi_script_name =404;
+
+            # Turn off chunked transfer encoding in HTTP/1.1. Older BF2 client or server python files may not be able to handle it
+            chunked_transfer_encoding off;
+
+            # Disable fastcgi output buffering
+            fastcgi_buffering off;
+
+            # Set fastcgi max execution response time
+            fastcgi_read_timeout 10s;
+            fastcgi_split_path_info ^(.+\.aspx)(/.+)$;
+            include fastcgi_params;
+            fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+            fastcgi_index index.aspx;
+            fastcgi_pass asp-php:9000;
+        }
+
+        location ~ \.php$ {
             # Check that the PHP script exists before passing it
             try_files $fastcgi_script_name =404;
 


### PR DESCRIPTION
Older BF2 client or server python files may not be able to handle it.