### PR TITLE
Feature: Add ability to hide player in `ASP`, and hide player or bots in `bf2sclone`

### DIFF
--- a/config/bf2sclone/config.inc.php
+++ b/config/bf2sclone/config.inc.php
@@ -14,4 +14,10 @@ define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
+
+// Whether to hide bots on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_BOTS', false);
+
+// Whether to hide hidden players on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/docs/bf2hub-bf2stats-example/config/bf2sclone/config.inc.php
+++ b/docs/bf2hub-bf2stats-example/config/bf2sclone/config.inc.php
@@ -14,4 +14,10 @@ define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
+
+// Whether to hide bots on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_BOTS', false);
+
+// Whether to hide hidden players on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/docs/full-bf2-stack-example/config/bf2sclone/config.inc.php
+++ b/docs/full-bf2-stack-example/config/bf2sclone/config.inc.php
@@ -14,4 +14,10 @@ define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
+
+// Whether to hide bots on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_BOTS', false);
+
+// Whether to hide hidden players on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/src/ASP/bf2statistics.php
+++ b/src/ASP/bf2statistics.php
@@ -23,7 +23,7 @@
 | Define Constants
 | ---------------------------------------------------------------
 */
-    define('CODE_VER', '2.3.3');
+    define('CODE_VER', '2.4.0');
     define('CODE_VER_DATE', '2013-03-12');
 	define('TIME_START', microtime(1));
 	define('DS', DIRECTORY_SEPARATOR);

--- a/src/ASP/frontend/js/views/manageplayers.js
+++ b/src/ASP/frontend/js/views/manageplayers.js
@@ -69,6 +69,7 @@ $(document).ready(function() {
 		$('#player-clantag').attr('value', result.clantag );
 		$('#player-rank').val( result.rank );
 		$('#player-ban').val( result.permban );
+		$('#player-hidden').val( result.hidden );
 		
 		// Open the Modal Window
 		Modal.dialog("option", {

--- a/src/ASP/frontend/views/manageplayers.tpl
+++ b/src/ASP/frontend/views/manageplayers.tpl
@@ -13,6 +13,7 @@
 					<th>Score</th>
 					<th>Country</th>
 					<th>Permban</th>
+					<th>Hidden</th>
 					<th>Action</th>
 				</tr>
 			</thead>
@@ -80,6 +81,15 @@
 							<label>Perm Ban:</label>
 							<div class="mws-form-item large">
 								<select id="player-ban" name="permban">
+									<option value="0">No</option>
+									<option value="1">Yes</option>
+								</select>
+							</div>
+						</div>
+						<div class="mws-form-row">
+							<label>Hidden:</label>
+							<div class="mws-form-item large">
+								<select id="player-hidden" name="hidden">
 									<option value="0">No</option>
 									<option value="1">Yes</option>
 								</select>

--- a/src/ASP/getleaderboard.aspx
+++ b/src/ASP/getleaderboard.aspx
@@ -100,14 +100,14 @@ else
 	{
 		if ($id == 'overall')
 		{
-			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `score` > 0");
+			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `hidden` = 0 AND `score` > 0");
 			$count = $result->fetchColumn();
 			$out .= "D\t{$count}\t" . time() . "\n";
 			$out .= "H\tn\tpid\tnick\tscore\ttotaltime\tplayerrank\tcountrycode\n";
 			
 			if(!$pid)
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `score` FROM `player` WHERE `score` > 0 ORDER BY `score` DESC, `name` DESC LIMIT {$min}, {$max}";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `score` FROM `player` WHERE `hidden` = 0 AND `score` > 0 ORDER BY `score` DESC, `name` DESC LIMIT {$min}, {$max}";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -125,7 +125,7 @@ else
 			}
 			else
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `score` FROM `player` WHERE `score` > 0 ORDER BY `score` DESC, `name` DESC";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `score` FROM `player` WHERE `hidden` = 0 AND `score` > 0 ORDER BY `score` DESC, `name` DESC";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -149,14 +149,14 @@ else
 		}
 		elseif ($id == 'commander')
 		{
-			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `cmdscore` > 0");
+			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `hidden` = 0 AND `cmdscore` > 0");
 			$count = $result->fetchColumn();
 			$out .= "D\t{$count}\t" . time() . "\n";
 			$out .= "H\tn\tpid\tnick\tcoscore\tcotime\tplayerrank\tcountrycode\n";
 			
 			if(!$pid)
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `cmdtime`, `cmdscore` FROM `player` WHERE `cmdscore` > 0 ORDER BY `cmdscore` DESC, `name` DESC LIMIT {$min}, {$max}";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `cmdtime`, `cmdscore` FROM `player` WHERE `hidden` = 0 AND `cmdscore` > 0 ORDER BY `cmdscore` DESC, `name` DESC LIMIT {$min}, {$max}";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -174,7 +174,7 @@ else
 			}
 			else
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `cmdtime`, `cmdscore` FROM `player` WHERE `cmdscore` > 0 ORDER BY `cmdscore` DESC, `name` DESC";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `cmdtime`, `cmdscore` FROM `player` WHERE `hidden` = 0 AND `cmdscore` > 0 ORDER BY `cmdscore` DESC, `name` DESC";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -198,14 +198,14 @@ else
 		}
 		elseif ($id ==  'team')
 		{
-			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `teamscore` > 0");
+			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `hidden` = 0 AND `teamscore` > 0");
 			$count = $result->fetchColumn();
 			$out .= "D\t{$count}\t" . time() . "\n";
 			$out .= "H\tn\tpid\tnick\tteamscore\ttotaltime\tplayerrank\tcountrycode\n";
 			
 			if(!$pid)
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `teamscore` FROM `player` WHERE `teamscore` > 0 ORDER BY `teamscore` DESC, `name` DESC LIMIT {$min}, {$max}";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `teamscore` FROM `player` WHERE `hidden` = 0 AND `teamscore` > 0 ORDER BY `teamscore` DESC, `name` DESC LIMIT {$min}, {$max}";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -223,7 +223,7 @@ else
 			}
 			else
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `teamscore` FROM `player` WHERE `teamscore` > 0 ORDER BY `teamscore` DESC, `name` DESC";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `teamscore` FROM `player` WHERE `hidden` = 0 AND `teamscore` > 0 ORDER BY `teamscore` DESC, `name` DESC";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -246,14 +246,14 @@ else
 		}
 		elseif ($id == 'combat')
 		{
-			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `skillscore` > 0");
+			$result = $connection->query("SELECT COUNT(`id`) FROM `player` WHERE `hidden` = 0 AND `skillscore` > 0");
 			$count = $result->fetchColumn();
 			$out .= "D\t{$count}\t" . time() . "\n";
 			$out .= "H\tn\tpid\tnick\tscore\ttotalkills\ttotaltime\tplayerrank\tcountrycode\n";
 			
 			if(!$pid)
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `kills`, `skillscore` FROM `player` WHERE `skillscore` > 0 ORDER BY `skillscore` DESC, `name` DESC LIMIT {$min}, {$max}";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `kills`, `skillscore` FROM `player` WHERE `hidden` = 0 AND `skillscore` > 0 ORDER BY `skillscore` DESC, `name` DESC LIMIT {$min}, {$max}";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -272,7 +272,7 @@ else
 			}
 			else
 			{
-				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `kills`, `skillscore` FROM `player` WHERE `skillscore` > 0 ORDER BY `skillscore` DESC, `name` DESC";
+				$query = "SELECT `id`, `name`, `rank`, `country`, `time`, `kills`, `skillscore` FROM `player` WHERE `hidden` = 0 AND `skillscore` > 0 ORDER BY `skillscore` DESC, `name` DESC";
 				$result = $connection->query($query);
                 if($result instanceof PDOStatement)
                 {
@@ -299,7 +299,7 @@ else
 	# Need weekly score calculations!
 	elseif ($type == 'risingstar')
 	{
-		$query = "SELECT COUNT(DISTINCT(`id`)) FROM `player_history` WHERE `score` > 0 AND `timestamp` >= (UNIX_TIMESTAMP() - (60*60*24*7))";
+		$query = "SELECT COUNT(DISTINCT(h.`id`)) FROM `player_history` h INNER JOIN player p ON p.id = h.id WHERE p.hidden = 0 AND h.`score` > 0 AND h.`timestamp` >= (UNIX_TIMESTAMP() - (60*60*24*7))";
 		$result = $connection->query($query);
         $count = $result->fetchColumn();
 		$out .= "D\t{$count}\t" . time() . "\n";
@@ -309,7 +309,7 @@ else
 		{
 			$query = "SELECT p.id, p.name, p.rank, p.country, p.time, sum(h.score) as weeklyscore, p.joined
 				FROM player AS p JOIN player_history AS h ON p.id = h.id
-				WHERE h.score > 0 AND h.timestamp >= (UNIX_TIMESTAMP() - (60*60*24*7))
+				WHERE p.hidden = 0 AND h.score > 0 AND h.timestamp >= (UNIX_TIMESTAMP() - (60*60*24*7))
 				GROUP BY p.id
 				ORDER BY weeklyscore DESC, name DESC
 				LIMIT {$min}, {$max}";
@@ -333,7 +333,7 @@ else
 		{
 			$query = "SELECT p.id, p.name, p.rank, p.country, p.time, sum(h.score) as weeklyscore, p.joined
 				FROM player AS p JOIN player_history AS h ON p.id = h.id
-				WHERE h.score > 0 AND h.timestamp >= (UNIX_TIMESTAMP() - (60*60*24*7))
+				WHERE p.hidden = 0 AND h.score > 0 AND h.timestamp >= (UNIX_TIMESTAMP() - (60*60*24*7))
 				GROUP BY p.id
 				ORDER BY weeklyscore DESC, name DESC";
 			$result = $connection->query($query);
@@ -360,14 +360,14 @@ else
 	}
 	elseif ($type == 'kit')
 	{
-		$result = $connection->query("SELECT COUNT(`id`) FROM `kits` WHERE `kills{$id}` > 0");
+		$result = $connection->query("SELECT COUNT(k.id) FROM kits k INNER JOIN player p ON p.id = k.id WHERE p.hidden = 0 AND `kills{$id}` > 0");
         $count = $result->fetchColumn();
 		$out .= "D\t{$count}\t" . time() . "\n";
 		$out .= "H\tn\tpid\tnick\tkillswith\tdeathsby\ttimeplayed\tplayerrank\tcountrycode\n";
 		
 		if(!$pid)
 		{
-			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN kits WHERE kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC LIMIT {$min}, {$max}";
+			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN kits WHERE hidden = 0 AND kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC LIMIT {$min}, {$max}";
 			$result = $connection->query($query);
             if($result instanceof PDOStatement)
             {
@@ -386,7 +386,7 @@ else
 		}
 		else
 		{
-			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN kits WHERE kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC";
+			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN kits WHERE hidden = 0 AND kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC";
 			$result = $connection->query($query);
             if($result instanceof PDOStatement)
             {
@@ -411,14 +411,14 @@ else
 	}
 	elseif ($type == 'vehicle')
 	{
-		$result = $connection->query("SELECT COUNT(`id`) FROM `vehicles` WHERE `kills{$id}` > 0");
+		$result = $connection->query("SELECT COUNT(v.id) FROM vehicles v INNER JOIN player p ON p.id = v.id WHERE p.hidden = 0 AND `kills{$id}` > 0");
         $count = $result->fetchColumn();
 		$out .= "D\t{$count}\t" . time() . "\n";
 		$out .= "H\tn\tpid\tnick\tkillswith\tdetahsby\ttimeused\tplayerrank\tcountrycode\n";
 		
 		if(!$pid)
 		{
-			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN vehicles WHERE kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC LIMIT {$min}, {$max}";
+			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN vehicles WHERE hidden = 0 AND kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC LIMIT {$min}, {$max}";
 			$result = $connection->query($query);
             if($result instanceof PDOStatement)
             {
@@ -437,7 +437,7 @@ else
 		}
 		else
 		{
-			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN vehicles WHERE kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC";
+			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time FROM player NATURAL JOIN vehicles WHERE hidden = 0 AND kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC";
 			$result = $connection->query($query);
             if($result instanceof PDOStatement)
             {
@@ -462,7 +462,7 @@ else
 	}
 	elseif ($type == 'weapon')
 	{
-		$result = $connection->query("SELECT COUNT(`id`) FROM `weapons` WHERE `kills{$id}` > 0");
+		$result = $connection->query("SELECT COUNT(w.id) FROM weapons w INNER JOIN player p ON p.id = w.id WHERE p.hidden = 0 AND `kills{$id}` > 0");
         $count = $result->fetchColumn();
 		$out .= "D\t{$count}\t" . time() . "\n";
 		# NOTE: EA typo (deathsby=detahsby)
@@ -470,7 +470,7 @@ else
         
 		if (!$pid)
 		{
-			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time, hit{$id} AS hit, fired{$id} AS fired FROM player NATURAL JOIN weapons WHERE kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC LIMIT {$min}, {$max}";
+			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time, hit{$id} AS hit, fired{$id} AS fired FROM player NATURAL JOIN weapons WHERE hidden = 0 AND kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC LIMIT {$min}, {$max}";
 			$result = $connection->query($query);
             if($result instanceof PDOStatement)
             {
@@ -490,7 +490,7 @@ else
 		}
 		else
 		{
-			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time, hit{$id} AS hit, fired{$id} AS fired FROM player NATURAL JOIN weapons WHERE kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC";
+			$query = "SELECT player.id AS plid, name, rank, country, kills{$id} AS kills, deaths{$id} AS deaths, time{$id} AS time, hit{$id} AS hit, fired{$id} AS fired FROM player NATURAL JOIN weapons WHERE hidden = 0 AND kills{$id} > 0 ORDER BY kills{$id} DESC, name DESC";
 			$result = $connection->query($query);
             if($result instanceof PDOStatement)
             {

--- a/src/ASP/index.php
+++ b/src/ASP/index.php
@@ -24,7 +24,7 @@
 | ---------------------------------------------------------------
 */
     define('BF2_ADMIN', 1);
-    define('CODE_VER', '2.3.3');
+    define('CODE_VER', '2.4.0');
     define('CODE_VER_DATE', '2013-03-12');
     define('DS', DIRECTORY_SEPARATOR);
     define('ROOT', dirname(__FILE__));

--- a/src/ASP/searchforplayers.aspx
+++ b/src/ASP/searchforplayers.aspx
@@ -83,7 +83,7 @@ else
 		"D\t" . time() . "\n" .
 		"H\tn\tpid\tnick\tscore\n";
 	
-	$query = "SELECT `id`, `name`, `score` FROM `player` WHERE `name` LIKE '%". substr($connection->quote($nick), 1, -1) ."%'";
+	$query = "SELECT `id`, `name`, `score` FROM `player` WHERE `name` LIKE '%". substr($connection->quote($nick), 1, -1) ."%' AND `hidden` = 0";
 	$result = $connection->query($query);
 	if($result instanceof PDOStatement)
 	{

--- a/src/ASP/system/database/sql.dbupgrade.php
+++ b/src/ASP/system/database/sql.dbupgrade.php
@@ -136,7 +136,11 @@ $sqlupgrade[] = array('Alter Player Table (Add `isbot` column)', '1.5.0',
 		"ALTER TABLE `mapinfo` 
 			CHANGE `id` `id` SMALLINT(4) UNSIGNED NOT NULL DEFAULT  '0'"); 
 */
-	
+
+$sqlupgrade[] = array('Alter Player Table (Add `hidden` column)', '2.4.0',
+"ALTER TABLE `player`
+	ADD COLUMN `hidden` int(6) unsigned NOT NULL default '0';");
+
 $sqlupgrade[] = array('Update Version Table', CODE_VER,
 	"INSERT INTO `_version` VALUES ('". CODE_VER ."', ".time().");");
 

--- a/src/ASP/system/modules/Manageplayers.php
+++ b/src/ASP/system/modules/Manageplayers.php
@@ -38,7 +38,7 @@ class Manageplayers
 		/* Array of database columns which should be read and sent back to DataTables. Use a space where
 		 * you want to insert a non-database field (for example a counter or static image)
 		 */
-		$aColumns = array( 'id', 'name', 'clantag', 'rank', 'score', 'country', 'permban' );
+		$aColumns = array( 'id', 'name', 'clantag', 'rank', 'score', 'country', 'permban', 'hidden' );
 		
 		/* Indexed column (used for fast and accurate table cardinality) */
 		$sIndexColumn = "id";
@@ -169,7 +169,7 @@ class Manageplayers
 		{
 			case "fetch":
 				// Get the player
-				$query = "SELECT `name`, `rank`, `permban`, `clantag` FROM `player` WHERE `id` = ". intval($pid);
+				$query = "SELECT `name`, `rank`, `permban`, `clantag`, `hidden` FROM `player` WHERE `id` = ". intval($pid);
 				$result = $DB->query( $query );
 				if(!($result instanceof PDOStatement) || !is_array(($row = $result->fetch())))
 				{
@@ -205,7 +205,8 @@ class Manageplayers
 					`availunlocks` = {$unlocks['availunlocks']}, 
 					`usedunlocks` = {$unlocks['usedunlocks']},				
 					`permban` = ". intval($_POST['permban']) .", 
-					`clantag` = ". $DB->quote($_POST['clantag']) ."
+					`clantag` = ". $DB->quote($_POST['clantag']) .",
+					`hidden` = ". $DB->quote($_POST['hidden']) ."
 					WHERE id = ". intval($pid);
 				if($DB->exec($query) === false)
 				{

--- a/src/bf2sclone/config.inc.php
+++ b/src/bf2sclone/config.inc.php
@@ -14,4 +14,10 @@ define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
+
+// Whether to hide bots on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_BOTS', false);
+
+// Whether to hide hidden players on the leaderboard frontpage
+define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/src/bf2sclone/index.php
+++ b/src/bf2sclone/index.php
@@ -98,6 +98,10 @@ if($GO == "0" && $PID)
 	{
 		// Load Player Data
 		$player 		= getPlayerDataFromPID($PID); // receive player data
+		if (!$player) {
+			header("Location: /"); // Redirect to home, since there's no such player
+			exit();
+		}
 		$victims 		= getFavouriteVictims($PID); // receive victim data
 		$enemies 		= getFavouriteEnemies($PID); // receive enemie data
 		$armies 		= getArmyData($PID); // receive army data

--- a/src/bf2sclone/queries/getEnemiesByPID.php
+++ b/src/bf2sclone/queries/getEnemiesByPID.php
@@ -1,4 +1,12 @@
 <?php
-	$query = "SELECT attacker, count FROM kills where victim = $PID ORDER BY count DESC LIMIT 11;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND player.isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND player.hidden = 0';
+	}
+
+	$query = "SELECT attacker, count FROM kills INNER JOIN player ON kills.attacker = player.id WHERE victim = $PID $WHERE ORDER BY count DESC LIMIT 11;";
 ?>
 

--- a/src/bf2sclone/queries/getLeaderBoardEntry.php
+++ b/src/bf2sclone/queries/getLeaderBoardEntry.php
@@ -1,5 +1,13 @@
 <?php
-	$query = 'SELECT id,name,kills,rank,score,(score/(time/60)) as spm, (kills/deaths) as kdr, time, country FROM player WHERE';
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+	
+	$query = 'SELECT id,name,kills,rank,score,(score/(time/60)) as spm, (kills/deaths) as kdr, time, country FROM player WHERE (';
 	if ($LEADERBOARD)
 	{
 		$first = true;
@@ -13,8 +21,8 @@
 			else
 				$query .= "or id='$value'";
 		}
-		$query .= ' ORDER BY SCORE DESC LIMIT 50;';
+		$query .= ") $WHERE ORDER BY SCORE DESC LIMIT 50;";
 	}
 	else
-		$query = "SELECT id,name,rank,kills,score,(score/(time/60)) as spm, (kills/deaths) as kdr, time, country FROM player WHERE score > 0 ORDER BY SCORE DESC LIMIT 10;";
+		$query = "SELECT id,name,rank,kills,score,(score/(time/60)) as spm, (kills/deaths) as kdr, time, country FROM player WHERE score > 0 $WHERE ORDER BY SCORE DESC LIMIT 10;";
 ?>

--- a/src/bf2sclone/queries/getNameFromPID.php
+++ b/src/bf2sclone/queries/getNameFromPID.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT name FROM player WHERE id = $PID;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+	
+	$query = "SELECT name FROM player WHERE id = $PID $WHERE;";
 ?>

--- a/src/bf2sclone/queries/getPIDList.php
+++ b/src/bf2sclone/queries/getPIDList.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,score,(score/(time/60)) as spm, (kills/deaths) as kdr, time, country FROM player WHERE name LIKE '$SEARCHVALUE' OR name LIKE ' $SEARCHVALUE' OR id = '$SEARCHVALUE' ORDER BY score DESC LIMIT 30;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,score,(score/(time/60)) as spm, (kills/deaths) as kdr, time, country FROM player WHERE (name LIKE '$SEARCHVALUE' OR name LIKE ' $SEARCHVALUE' OR id = '$SEARCHVALUE') $WHERE ORDER BY score DESC LIMIT 30;";
 ?>

--- a/src/bf2sclone/queries/getPlayerData.php
+++ b/src/bf2sclone/queries/getPlayerData.php
@@ -1,4 +1,11 @@
 <?php
-	$query = "SELECT * FROM player WHERE id = $PID;";
-?>
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
 
+	$query = "SELECT * FROM player WHERE id = $PID $WHERE;";
+?>

--- a/src/bf2sclone/queries/getRankFromPID.php
+++ b/src/bf2sclone/queries/getRankFromPID.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT rank FROM player WHERE id = $PID;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT rank FROM player WHERE id = $PID $WHERE;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopCMD.php
+++ b/src/bf2sclone/queries/getRankingTopCMD.php
@@ -1,3 +1,12 @@
+
 <?php
-	$query = "SELECT id,name,rank,cmdscore/cmdtime as cmd ,country FROM player WHERE 1=1 ORDER BY cmd DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,cmdscore/cmdtime as cmd ,country FROM player WHERE 1=1 $WHERE ORDER BY cmd DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopCaptures.php
+++ b/src/bf2sclone/queries/getRankingTopCaptures.php
@@ -1,4 +1,12 @@
 <?php
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
 	#WHERE captures>0 
-	$query = "SELECT id,name,rank, captures,country FROM player WHERE 1=1 ORDER BY captures DESC LIMIT 5;";
+	$query = "SELECT id,name,rank, captures,country FROM player WHERE 1=1 $WHERE ORDER BY captures DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopCmdScore.php
+++ b/src/bf2sclone/queries/getRankingTopCmdScore.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,cmdscore,country FROM player WHERE 1=1 ORDER BY cmdscore DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,cmdscore,country FROM player WHERE 1=1 $WHERE ORDER BY cmdscore DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopFlagwork.php
+++ b/src/bf2sclone/queries/getRankingTopFlagwork.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,captureassists+captures+neutralizes+defends as flagwork,country FROM player WHERE 1=1 ORDER BY flagwork DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,captureassists+captures+neutralizes+defends as flagwork,country FROM player WHERE 1=1 $WHERE ORDER BY flagwork DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopKDR.php
+++ b/src/bf2sclone/queries/getRankingTopKDR.php
@@ -1,4 +1,12 @@
 <?php
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
 	#NOTE: minimum 1 death
-	$query = "SELECT id,name,rank, kills/deaths as kdr,country FROM player WHERE 1=1 ORDER BY kdr DESC LIMIT 5;";
+	$query = "SELECT id,name,rank, kills/deaths as kdr,country FROM player WHERE 1=1 $WHERE ORDER BY kdr DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopKills.php
+++ b/src/bf2sclone/queries/getRankingTopKills.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,kills,country FROM player WHERE 1=1 ORDER BY kills DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,kills,country FROM player WHERE 1=1 $WHERE ORDER BY kills DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopRndScore.php
+++ b/src/bf2sclone/queries/getRankingTopRndScore.php
@@ -1,4 +1,12 @@
 <?php
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
 	#NOTE: minimum 1 death
-	$query = "SELECT id,name,rank, rndscore,country FROM player WHERE 1=1 ORDER BY rndscore DESC LIMIT 5;";
+	$query = "SELECT id,name,rank, rndscore,country FROM player WHERE 1=1 $WHERE ORDER BY rndscore DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopSPM.php
+++ b/src/bf2sclone/queries/getRankingTopSPM.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,score/(time/60) as spm,country FROM player WHERE 1=1 ORDER BY spm DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,score/(time/60) as spm,country FROM player WHERE 1=1 $WHERE ORDER BY spm DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopSani.php
+++ b/src/bf2sclone/queries/getRankingTopSani.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,heals+revives as sani ,country FROM player WHERE 1=1 ORDER BY sani DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,heals+revives as sani ,country FROM player WHERE 1=1 $WHERE ORDER BY sani DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopScore.php
+++ b/src/bf2sclone/queries/getRankingTopScore.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,score,country FROM player WHERE 1=1 ORDER BY score DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,score,country FROM player WHERE 1=1 $WHERE ORDER BY score DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopTeamwork.php
+++ b/src/bf2sclone/queries/getRankingTopTeamwork.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id,name,rank,teamscore-(teamdamage+teamkills+teamvehicledamage) as teamwork,country FROM player WHERE teamscore>(teamdamage+teamkills+teamvehicledamage) ORDER BY teamwork DESC LIMIT 5;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id,name,rank,teamscore-(teamdamage+teamkills+teamvehicledamage) as teamwork,country FROM player WHERE teamscore>(teamdamage+teamkills+teamvehicledamage) $WHERE ORDER BY teamwork DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getRankingTopWLR.php
+++ b/src/bf2sclone/queries/getRankingTopWLR.php
@@ -1,4 +1,12 @@
 <?php
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+	
 	#NOTE: minimum 1 death
-	$query = "SELECT id,name,rank, wins/losses as wlr,country FROM player WHERE 1=1 ORDER BY wlr DESC LIMIT 5;";
+	$query = "SELECT id,name,rank, wins/losses as wlr,country FROM player WHERE 1=1 $WHERE ORDER BY wlr DESC LIMIT 5;";
 ?>

--- a/src/bf2sclone/queries/getTopPlayers.php
+++ b/src/bf2sclone/queries/getTopPlayers.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT id, rank, country, name, score, time, (score/(time/60)) as spm, (kills/deaths) as kdr FROM player ORDER BY score DESC LIMIT ". LEADERBOARD_COUNT .";";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND hidden = 0';
+	}
+
+	$query = "SELECT id, rank, country, name, score, time, (score/(time/60)) as spm, (kills/deaths) as kdr FROM player WHERE 1=1 $WHERE ORDER BY score DESC LIMIT ". LEADERBOARD_COUNT .";";
 ?>

--- a/src/bf2sclone/queries/getVictimsByPID.php
+++ b/src/bf2sclone/queries/getVictimsByPID.php
@@ -1,3 +1,11 @@
 <?php
-	$query = "SELECT victim, count FROM kills WHERE attacker = $PID ORDER BY count DESC LIMIT 11;";
+	$WHERE = '';
+	if (LEADERBOARD_HIDE_BOTS) {
+		$WHERE .= ' AND player.isbot = 0';
+	}
+	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+		$WHERE .= ' AND player.hidden = 0';
+	}
+
+	$query = "SELECT victim, count FROM kills INNER JOIN player ON kills.victim = player.id WHERE attacker = $PID $WHERE ORDER BY count DESC LIMIT 11;";
 ?>


### PR DESCRIPTION
`ASP`:
 - `Manage Players > Manage Players` module can be used to hide players in `ASP`.
- To be clear, hidden players continue to be ranked. They are hidden from leaderboards and search in BFHQ, but may still appear in other places, e.g. Favourite opponent or favourite victim.

`bf2sclone`:
- Use `LEADERBOARD_HIDE_BOTS` and `LEADERBOARD_HIDE_HIDDEN_PLAYERS` in `config.inc.php` to control whether to hide bots and players respectively. 
- In contrast to BFHQ, hidden players do not show up at all in leaderboards, search, rankings, favourite opponents, favourite victim etc.