### PR TITLE
Refactor (bf2sclone): Rename config options to `RANKING_HIDE_BOTS` and `RANKING_HIDE_HIDDEN_PLAYERS`

### DIFF
--- a/config/bf2sclone/config.inc.php
+++ b/config/bf2sclone/config.inc.php
@@ -12,12 +12,12 @@ $TITLE = 'BF2S Clone';
 // Refresh time in seconds for stats
 define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
+// Whether to hide bots from rankings
+define ('RANKING_HIDE_BOTS', false);
+
+// Whether to hide hidden players from rankings
+define ('RANKING_HIDE_HIDDEN_PLAYERS', false);
+
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
-
-// Whether to hide bots on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_BOTS', false);
-
-// Whether to hide hidden players on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/docs/bf2hub-bf2stats-example/config/bf2sclone/config.inc.php
+++ b/docs/bf2hub-bf2stats-example/config/bf2sclone/config.inc.php
@@ -12,12 +12,12 @@ $TITLE = 'BF2S Clone';
 // Refresh time in seconds for stats
 define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
+// Whether to hide bots from rankings
+define ('RANKING_HIDE_BOTS', false);
+
+// Whether to hide hidden players from rankings
+define ('RANKING_HIDE_HIDDEN_PLAYERS', false);
+
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
-
-// Whether to hide bots on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_BOTS', false);
-
-// Whether to hide hidden players on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/docs/full-bf2-stack-example/config/bf2sclone/config.inc.php
+++ b/docs/full-bf2-stack-example/config/bf2sclone/config.inc.php
@@ -12,12 +12,12 @@ $TITLE = 'BF2S Clone';
 // Refresh time in seconds for stats
 define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
+// Whether to hide bots from rankings
+define ('RANKING_HIDE_BOTS', false);
+
+// Whether to hide hidden players from rankings
+define ('RANKING_HIDE_HIDDEN_PLAYERS', false);
+
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
-
-// Whether to hide bots on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_BOTS', false);
-
-// Whether to hide hidden players on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/src/bf2sclone/config.inc.php
+++ b/src/bf2sclone/config.inc.php
@@ -12,12 +12,12 @@ $TITLE = 'BF2S Clone';
 // Refresh time in seconds for stats
 define ('RANKING_REFRESH_TIME', 600); // -> default: 600 seconds (10 minutes)
 
+// Whether to hide bots from rankings
+define ('RANKING_HIDE_BOTS', false);
+
+// Whether to hide hidden players from rankings
+define ('RANKING_HIDE_HIDDEN_PLAYERS', false);
+
 // Number of players to show on the leaderboard frontpage
 define ('LEADERBOARD_COUNT', 25);
-
-// Whether to hide bots on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_BOTS', false);
-
-// Whether to hide hidden players on the leaderboard frontpage
-define ('LEADERBOARD_HIDE_HIDDEN_PLAYERS', false);
 ?>

--- a/src/bf2sclone/queries/getEnemiesByPID.php
+++ b/src/bf2sclone/queries/getEnemiesByPID.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND player.isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND player.hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getLeaderBoardEntry.php
+++ b/src/bf2sclone/queries/getLeaderBoardEntry.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 	

--- a/src/bf2sclone/queries/getNameFromPID.php
+++ b/src/bf2sclone/queries/getNameFromPID.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 	

--- a/src/bf2sclone/queries/getPIDList.php
+++ b/src/bf2sclone/queries/getPIDList.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getPlayerData.php
+++ b/src/bf2sclone/queries/getPlayerData.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankFromPID.php
+++ b/src/bf2sclone/queries/getRankFromPID.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopCMD.php
+++ b/src/bf2sclone/queries/getRankingTopCMD.php
@@ -1,10 +1,10 @@
 
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopCaptures.php
+++ b/src/bf2sclone/queries/getRankingTopCaptures.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopCmdScore.php
+++ b/src/bf2sclone/queries/getRankingTopCmdScore.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopFlagwork.php
+++ b/src/bf2sclone/queries/getRankingTopFlagwork.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopKDR.php
+++ b/src/bf2sclone/queries/getRankingTopKDR.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopKills.php
+++ b/src/bf2sclone/queries/getRankingTopKills.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopRndScore.php
+++ b/src/bf2sclone/queries/getRankingTopRndScore.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopSPM.php
+++ b/src/bf2sclone/queries/getRankingTopSPM.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopSani.php
+++ b/src/bf2sclone/queries/getRankingTopSani.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopScore.php
+++ b/src/bf2sclone/queries/getRankingTopScore.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopTeamwork.php
+++ b/src/bf2sclone/queries/getRankingTopTeamwork.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getRankingTopWLR.php
+++ b/src/bf2sclone/queries/getRankingTopWLR.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 	

--- a/src/bf2sclone/queries/getTopPlayers.php
+++ b/src/bf2sclone/queries/getTopPlayers.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND hidden = 0';
 	}
 

--- a/src/bf2sclone/queries/getVictimsByPID.php
+++ b/src/bf2sclone/queries/getVictimsByPID.php
@@ -1,9 +1,9 @@
 <?php
 	$WHERE = '';
-	if (LEADERBOARD_HIDE_BOTS) {
+	if (RANKING_HIDE_BOTS) {
 		$WHERE .= ' AND player.isbot = 0';
 	}
-	if (LEADERBOARD_HIDE_HIDDEN_PLAYERS) {
+	if (RANKING_HIDE_HIDDEN_PLAYERS) {
 		$WHERE .= ' AND player.hidden = 0';
 	}
 


### PR DESCRIPTION
Renames config options introduced in #80, to make them more understandable that they apply globally rather than to just the leaderboard.