### PR TITLE
Fix (ASP): Fix `Installdb` module to autofill values using `config.php` to easily set up the DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ See [this](docs/bf2hub-bf2stats-example) example showing how to deploy [Battlefi
 ```sh
 # 1. Start BF2 server, Gamespy server, and bf2stats
 docker-compose up
-# ASP available at http://localhost:8081/ASP. Username: admin, password admin. See ./config/ASP/config.php
-# bf2sclone available at http://localhost:8082.
+# ASP available at http://localhost:8081/ASP. Username: admin, password admin. Login and set up the DB the first time. See ./config/ASP/config.php
+# bf2sclone available at http://localhost:8082
 # phpmyadmin available at http://localhost:8083. Username: admin, password: admin. See ./config/ASP/config.php config file
 
-# 2. To setup the DB the first time, use $db_host, $db_port, $db_name, $db_user, $db_pass in ./config/ASP/config.php. Then, restart the BF2 server for stats to be recorded
+# 2. If you have just setup the DB the first time, restart the BF2 server to begin recording stats
 docker-compose restart bf2
 
-# 3. Before launching the BF2 client, spoof gamespy DNS by adding these entries in C:\Windows\system32\drivers\etc\hosts
+# 3. Before launching the BF2 client, spoof gamespy DNS by adding these entries in C:\Windows\system32\drivers\etc\hosts. This is needed for the BF2 client to work correctly.
 # Replace '192.168.1.100' with your development machine's IP address
 192.168.1.100 battlefield2.available.gamespy.com
 192.168.1.100 battlefield2.master.gamespy.com
@@ -54,9 +54,9 @@ docker-compose restart bf2
 
 # Development - Install vscode extensions
 # Once installed, set breakpoints in code, and press F5 to start debugging.
-code --install-extension bmewburn.vscode-intelephense-client # PHP intellisense
-code --install-extension xdebug.php-debug # PHP remote debugging via xdebug
-code --install-extension ms-python.python # Python intellisense
+code-server --install-extension bmewburn.vscode-intelephense-client # PHP intellisense
+code-server --install-extension xdebug.php-debug # PHP remote debugging via xdebug
+code-server --install-extension ms-python.python # Python intellisense
 # If xdebug is not working, iptables INPUT chain may be set to DROP on the docker bridge.
 # Execute this to allow php to reach the host machine via the docker0 bridge
 sudo iptables -A INPUT -i br+ -j ACCEPT
@@ -66,7 +66,7 @@ docker-compose restart bf2
 # BF2 server - Attach to the bf2 server console
 docker attach $( docker-compose ps -q bf2 )
 # BF2 server - Exec into container
-docker exec -it $( docker-compose ps -q  bf2) bash
+docker exec -it $( docker-compose ps -q bf2) bash
 # BF2 server - Read python logs
 docker exec -it $( docker-compose ps -q bf2 ) bash -c 'cat python/bf2/logs/bf2game_*'
 # BF2 server - List snapshots
@@ -94,10 +94,10 @@ docker build -t startersclan/bf2stats:bf2sclone-nginx -f Dockerfile.bf2sclone-ng
 docker build -t startersclan/bf2stats:bf2sclone-php -f Dockerfile.bf2sclone-php.prod .
 
 # Dump the DB
-docker exec $( docker-compose ps | grep db | awk '{print $1}' ) mysqldump -uroot -padmin bf2stats | gzip > bf2stats.sql.gz
+docker exec $( docker-compose ps -q db ) mysqldump -uroot -padmin bf2stats | gzip > bf2stats.sql.gz
 
 # Restore the DB
-zcat bf2stats.sql.gz | docker exec -i $( docker-compose ps | grep db | awk '{print $1}' ) mysql -uroot -padmin bf2stats
+zcat bf2stats.sql.gz | docker exec -i $( docker-compose ps -q db ) mysql -uroot -padmin bf2stats
 
 # Stop BF2 server, gamespy server and bf2stats
 docker-compose down

--- a/docs/bf2hub-bf2stats-example/README.md
+++ b/docs/bf2hub-bf2stats-example/README.md
@@ -60,7 +60,7 @@ Visit https://asp.example.com/ASP and login using `$admin_user` and `$admin_pass
 
 > Since traefik hasn't got a valid TLS certificate via `ACME`, it will serve the `TRAEFIK DEFAULT CERT`. The browser will show a security issue when visiting https://asp.example.com, https://bf2sclone.example.com, and https://phpmyadmin.example.com. Simply click "visit site anyway" button to get past the security check.
 
-Click on `System > Install Database` and install the DB using `$db_host`,`$db_port`,`$db_name`,`$db_user`,`$db_pass` you defined in [`config.php`](./config/ASP/config.php). Click `System > Test System` and `Run System Tests` and all tests should be green, except for the `BF2Statistics Processing` test and the four `.aspx` tests, because we still don't have a Fully Qualified Domain Name (FQDN) with a public DNS record.
+Click `System > Install Database` and click `Install` (The `$db_host`,`$db_port`,`$db_name`,`$db_user`,`$db_pass` in [`config.php`](./config/ASP/config.php) will be autofilled). Once the DB is installed, click `System > Test System` and `Run System Tests` and all tests should be green, except for the `BF2Statistics Processing` test and the four `.aspx` tests, because we still don't have a Fully Qualified Domain Name (FQDN) with a public DNS record.
 
 Then, restart the BF2 server so that it begins recording stats:
 
@@ -107,17 +107,34 @@ iptables -A INPUT -p udp -m udp -m conntrack --ctstate NEW --dport 29900 -j ACCE
 iptables -A INPUT -p udp -m udp -m conntrack --ctstate NEW --dport 80 -j ACCEPT
 iptables -A INPUT -p udp -m udp -m conntrack --ctstate NEW --dport 443 -j ACCEPT
 
-# Attach to the bf2 server console
-docker attach bf2stats_bf2_1
+# BF2 server - Restart server
+docker-compose restart bf2
+# BF2 server - Attach to the bf2 server console
+docker attach $( docker-compose ps -q bf2 )
+# BF2 server - Exec into container
+docker exec -it $( docker-compose ps -q bf2) bash
+# BF2 server - Read python logs
+docker exec -it $( docker-compose ps -q bf2 ) bash -c 'cat python/bf2/logs/bf2game_*'
+# BF2 server - List snapshots
+docker exec -it $( docker-compose ps -q bf2 ) bash -c 'ls -al python/bf2/logs/snapshots/sent'
+docker exec -it $( docker-compose ps -q bf2 ) bash -c 'ls -al python/bf2/logs/snapshots/unsent'
 
-# Copy logs from bf2 server to this folder
-docker cp bf2stats_bf2_1:/server/bf2/python/bf2/logs .
+# asp-php - Exec into container
+docker exec -it $( docker-compose ps -q asp-php ) sh
+# asp-php - Read logs
+docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/php_errors.log
+docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/stats_debug.log
+docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_awards.log
+docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_ranks.log
+# asp-php - List snapshots
+docker exec -it $( docker-compose ps -q asp-php ) ls -al /src/ASP/system/snapshots/processed
+docker exec -it $( docker-compose ps -q asp-php ) ls -al /src/ASP/system/snapshots/temp
 
 # Dump the DB
-docker exec $( docker-compose ps | grep db | awk '{print $1}' ) mysqldump -uroot -padmin bf2stats | gzip > bf2stats.sql.gz
+docker exec $( docker-compose ps -q db ) mysqldump -uroot -padmin bf2stats | gzip > bf2stats.sql.gz
 
 # Restore the DB
-zcat bf2stats.sql.gz | docker exec -i $( docker-compose ps | grep db | awk '{print $1}' ) mysql -uroot -padmin bf2stats
+zcat bf2stats.sql.gz | docker exec -i $( docker-compose ps -q db ) mysql -uroot -padmin bf2stats
 
 # Stop
 docker-compose down

--- a/src/ASP/frontend/views/installdb.tpl
+++ b/src/ASP/frontend/views/installdb.tpl
@@ -19,31 +19,31 @@
 					<div class="mws-form-row">
 						<label>Database Host:</label>
 						<div class="mws-form-item small">
-							<input type="text" class="mws-textinput required" name="cfg__db_host" title="MySQL Database Host. Typically LOCALHOST."/>
+							<input type="text" class="mws-textinput required" name="cfg__db_host" value="{config.db_host}" title="MySQL Database Host. Typically LOCALHOST."/>
 						</div>
 					</div>
 					<div class="mws-form-row">
 						<label>Database Port:</label>
 						<div class="mws-form-item small">
-							<input type="text" class="mws-textinput required" name="cfg__db_port" title="MySQL database port. Typically 3306."/>
+							<input type="text" class="mws-textinput required" name="cfg__db_port" value="{config.db_port}" title="MySQL database port. Typically 3306."/>
 						</div>
 					</div>
 					<div class="mws-form-row">
 						<label>Database Name:</label>
 						<div class="mws-form-item small">
-							<input type="text" class="mws-textinput required" name="cfg__db_name" title="Database Name to store stats."/>
+							<input type="text" class="mws-textinput required" name="cfg__db_name" value="{config.db_name}" title="Database Name to store stats."/>
 						</div>
 					</div>
 					<div class="mws-form-row">
 						<label>Database Username:</label>
 						<div class="mws-form-item small">
-							<input type="text" class="mws-textinput required" name="cfg__db_user" title="Username with rights to Database."/>
+							<input type="text" class="mws-textinput required" name="cfg__db_user" value="{config.db_user}" title="Username with rights to Database."/>
 						</div>
 					</div>
 					<div class="mws-form-row">
 						<label>Database Password:</label>
 						<div class="mws-form-item small">
-							<input type="password" class="mws-textinput" name="cfg__db_pass" title="Password for Database Username."/>
+							<input type="password" class="mws-textinput" name="cfg__db_pass" value="{config.db_pass}" title="Password for Database Username."/>
 						</div>
 					</div>
 					<div class="mws-button-row">

--- a/src/ASP/system/modules/Installdb.php
+++ b/src/ASP/system/modules/Installdb.php
@@ -12,6 +12,7 @@ class Installdb
 		{
 			// Setup the template
 			$Template = new Template();
+			$Template->set('config', Config::FetchAll());
 			$Template->render('installdb');
 		}
 	}


### PR DESCRIPTION
In a dockerized setup, configuration is immutable. Hence, the ASP's `Installdb` module should use the mounted `config.php`'s values directly instead of allowing the user to fill in values that would then generate a `config.php`.