### PR TITLE
Fix (ASP): Log `php` errors to `stderr` when running in `docker`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ docker exec -it $( docker-compose ps -q bf2 ) bash -c 'ls -al python/bf2/logs/sn
 # asp-php - Exec into container
 docker exec -it $( docker-compose ps -q asp-php ) sh
 # asp-php - Read logs
-docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/php_errors.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/stats_debug.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_awards.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_ranks.log
@@ -128,7 +127,7 @@ git commit -m "Chore: Bump version to \`$TAG\`"
 
 ### Q: ASP installer never completes the first time
 
-A: This is caused by a bug where the UI fails to handle an invalid response from the backend. A `PHP_ERROR` `Warning: file_put_contents(/src/ASP/system/config/config.php): failed to open stream: Permission denied in /src/ASP/system/core/Config.php on line 165` is output before the JSON response causing invalid JSON. You can see the error in the `/src/ASP/system/logs/php_errors.log`.
+A: This is caused by a bug where the UI fails to handle an invalid response from the backend. A `PHP_ERROR` `Warning: file_put_contents(/src/ASP/system/config/config.php): failed to open stream: Permission denied in /src/ASP/system/core/Config.php on line 165` is output before the JSON response causing invalid JSON.
 
 Grant ASP `php`'s `www-data` user write permission for `config.php`.
 
@@ -148,7 +147,7 @@ docker-compose restart asp-php
 
 ### Q: `There was an error testing the system. Please refresh the page and try again.` when using `System > Test System` in ASP
 
-A: This is means the UI received an invalid JSON response from the backend. If you know how to, you can examine the payload of the `POST` response. You may also check for errors in the `/src/ASP/system/logs/php_errors.log`.
+A: This is means the UI received an invalid JSON response from the backend. If you know how to, you can examine the payload of the `POST` response.
 
 ### Q: `BF2Statistics Processing Check: Fail` or ` Gamespy (.aspx) Basic Response: Fail` or `Gamespy (.aspx) Advanced (1) Response: Fail` when using `System > Test System` in ASP
 

--- a/docs/bf2hub-bf2stats-example/README.md
+++ b/docs/bf2hub-bf2stats-example/README.md
@@ -122,7 +122,6 @@ docker exec -it $( docker-compose ps -q bf2 ) bash -c 'ls -al python/bf2/logs/sn
 # asp-php - Exec into container
 docker exec -it $( docker-compose ps -q asp-php ) sh
 # asp-php - Read logs
-docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/php_errors.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/stats_debug.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_awards.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_ranks.log

--- a/docs/full-bf2-stack-example/README.md
+++ b/docs/full-bf2-stack-example/README.md
@@ -192,7 +192,6 @@ docker exec -it $( docker-compose ps -q bf2 ) bash -c 'ls -al python/bf2/logs/sn
 # asp-php - Exec into container
 docker exec -it $( docker-compose ps -q asp-php ) sh
 # asp-php - Read logs
-docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/php_errors.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/stats_debug.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_awards.log
 docker exec -it $( docker-compose ps -q asp-php ) cat /src/ASP/system/logs/validate_ranks.log

--- a/src/ASP/bf2statistics.php
+++ b/src/ASP/bf2statistics.php
@@ -41,7 +41,10 @@
 */
 	error_reporting(E_ALL);
 	ini_set("log_errors", "1");
-	ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+	if (!getenv('PHP_VERSION')) {
+		# Not running in docker. Log errors to file
+		ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+	}
 	ini_set("display_errors", "0");
 
 	// Disable Zlib Compression

--- a/src/ASP/getclaninfo.aspx
+++ b/src/ASP/getclaninfo.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/getleaderboard.aspx
+++ b/src/ASP/getleaderboard.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/getmapinfo.aspx
+++ b/src/ASP/getmapinfo.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/getplayerid.aspx
+++ b/src/ASP/getplayerid.aspx
@@ -41,7 +41,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/getplayerinfo.aspx
+++ b/src/ASP/getplayerinfo.aspx
@@ -53,7 +53,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/getrankinfo.aspx
+++ b/src/ASP/getrankinfo.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/getunlocksinfo.aspx
+++ b/src/ASP/getunlocksinfo.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/index.php
+++ b/src/ASP/index.php
@@ -51,7 +51,10 @@
 */
     error_reporting(E_ALL);
     ini_set("log_errors", "1");
-    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+    if (!getenv('PHP_VERSION')) {
+        # Not running in docker. Log errors to file
+        ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+    }
     ini_set("display_errors", "0");
 
 /*

--- a/src/ASP/ranknotification.aspx
+++ b/src/ASP/ranknotification.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/searchforplayers.aspx
+++ b/src/ASP/searchforplayers.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression

--- a/src/ASP/selectunlock.aspx
+++ b/src/ASP/selectunlock.aspx
@@ -39,7 +39,10 @@ require(SYSTEM_PATH . DS . 'functions.php');
 // Set Error Reporting
 error_reporting(E_ALL);
 ini_set("log_errors", "1");
-ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+if (!getenv('PHP_VERSION')) {
+    # Not running in docker. Log errors to file
+    ini_set("error_log", SYSTEM_PATH . DS . 'logs' . DS . 'php_errors.log');
+}
 ini_set("display_errors", "0");
 
 //Disable Zlib Compression


### PR DESCRIPTION
Previously, `ASP` `php` errors were logged to a file (`/src/ASP/system/logs/php_errors.log`). When running in docker, logging to a file can trip up users of `docker` who expect errors to be logged to `stderr`.

Now, the env variable `PHP_VERSION` (present in official `php` images) is used to detect whether `ASP` is running in `docker`. If `ASP` is running in `docker`, `php` errors are logged to `stderr`. Otherwise, `php` errors are logged to a file.