### PR TITLE
Fix (ASP): Fix `Serverinfo` module to use gamespy query instead of Rcon to determine server online status

### DIFF
--- a/src/ASP/system/modules/Serverinfo.php
+++ b/src/ASP/system/modules/Serverinfo.php
@@ -109,8 +109,22 @@ class Serverinfo
         $data = array();
         foreach($result as $server)
         {
-            $result = $Rcon->connect($server['ip'], $server['rcon_port'], $server['rcon_password']);
-            if($result == 0)
+            // $result = $Rcon->connect($server['ip'], $server['rcon_port'], $server['rcon_password']);
+
+            // Open our socket to the server
+            $sock = @fsockopen("udp://". $server['ip'], $server['queryport']);
+            @socket_set_timeout($sock, 0, 500000);
+
+            // Query the gamespy data
+            $queryString = "\xFE\xFD\x00\x10\x20\x30\x40\xFF\xFF\xFF\x01";
+            @fwrite($sock, $queryString);
+
+            $buffer = '';
+            while (($char = @fgets($sock, 4096))) {
+                $buffer .= $char;
+            }
+            
+            if (!$buffer)
             {
                 $status = '<font color="red">Offline</font>';
             }


### PR DESCRIPTION
Previously, the ASP `ServerInfo` module used Rcon against the BF2 server to determine server status. However, the Rcon port may not always be available (i.e. not publically accessible). In contrast, the BF2 server gamespy port is always available to the public (to be listed on a master server) and is a better way to determine server status.

Now, a gamespy query is used to determine BF2 server status instead. If there is no response from the server, it is assumed to be offline.