### PR TITLE
Fix (ASP): Speed up `Serverinfo` module determination of server status by avoiding hitting socket timeout when possible

### DIFF
--- a/src/ASP/system/modules/Serverinfo.php
+++ b/src/ASP/system/modules/Serverinfo.php
@@ -105,7 +105,7 @@ class Serverinfo
     public function Process($result)
     {
         // Load the Rcon Class
-        $Rcon = new Rcon();
+        // $Rcon = new Rcon();
         $data = array();
         foreach($result as $server)
         {
@@ -119,22 +119,15 @@ class Serverinfo
             $queryString = "\xFE\xFD\x00\x10\x20\x30\x40\xFF\xFF\xFF\x01";
             @fwrite($sock, $queryString);
 
-            $buffer = '';
-            while (($char = @fgets($sock, 4096))) {
-                $buffer .= $char;
-            }
-            
-            if (!$buffer)
-            {
-                $status = '<font color="red">Offline</font>';
-            }
-            else
-            {
+            $bytes = @fread($sock, 5);
+            if ($bytes == "\x00\x10\x20\x30\x40") {
                 $status = '<font color="green">Online</font>';
+            } else {
+                $status = '<font color="red">Offline</font>';
             }
             
             // Close the connection
-            $Rcon->close();
+            // $Rcon->close();
             $data[$server['id']] = $status;
         }
         


### PR DESCRIPTION
Previously, 0.5s timeout is hit regardless of whether there is a gamespy query response from the server. However, to speed up the status checks, timeout should only be hit if the server does not respond.

Send the gamespy query, and wait for a response. If there is a response, validate the first 5 byte and the server is online. If there is no response for 0.5s, assume the server is offline.

Follow-up of #104