### PR TITLE
Feature: Add `publicaddress` column in `servers` table and ability to manage it in `ASP` `Serverinfo` module

### DIFF
--- a/src/ASP/frontend/views/serverinfo.tpl
+++ b/src/ASP/frontend/views/serverinfo.tpl
@@ -6,7 +6,9 @@
         <table class="mws-datatable-fn mws-table">
             <thead>
                 <tr>
-                    <th>Server Ip</th>
+                    <th>Server ID</th>
+                    <th>Public Address</th>
+                    <th>IP</th>
                     <th>Name</th>
                     <th>Prefix</th>
                     <th>Port</th>
@@ -18,6 +20,8 @@
             <tbody>
                 {servers}
                     <tr>
+                        <td>{id}</td>
+                        <td>{publicaddress}</td>
                         <td>{ip}</td>
                         <td>{name}</td>
                         <td>{prefix}</td>
@@ -26,7 +30,7 @@
                         <td><div id="status_{id}" style="text-align: center;"><img src="frontend/images/core/alerts/loading.gif"></div></td>
                         <td>
                             <center>
-                                <a href="?task=serverinfo&id={id}">View Server</a>&nbsp; - &nbsp;<a id="view" name="{id}" href="#">Set Rcon Data</a>
+                                <a href="?task=serverinfo&id={id}">View Server</a>&nbsp; - &nbsp;<a id="edit" name="{id}" href="#">Manage</a>
                             </center>
                         </td>
                     </tr>
@@ -34,15 +38,21 @@
             </tbody>
         </table>
         
-        <!-- Hidden Server Viewer -->
+        <!-- Hidden Ajax Thing -->
         <div id="ajax-dialog">
             <div class="mws-dialog-inner">
-                <form id="mws-validate" class="mws-form" action="?task=serverinfo" method="POST">
+                <form id="mws-validate" class="mws-form" action="?task=serverinfo&ajax=server" method="POST">
                     <input type="hidden" name="action" value="configure" />
                     <input type="hidden" name="id" id="server-id"/>
                     <div id="ajax-message" style="display: none;"></div>
                     
                     <div class="mws-form-inline">
+                        <div class="mws-form-row">
+                            <label>Public Address:</label>
+                            <div class="mws-form-item large">
+                                <input id="publicaddress" type="text" name="publicaddress" class="mws-textinput" placeholder="E.g. 1.2.3.4, bf2.example.com, etc."/>
+                            </div>
+                        </div>
                         <div class="mws-form-row">
                             <label>Rcon Port:</label>
                             <div class="mws-form-item large">

--- a/src/ASP/system/database/sql.dbschema.php
+++ b/src/ASP/system/database/sql.dbschema.php
@@ -344,6 +344,7 @@ $sqlschema[] = array('Round History Table',
 $sqlschema[] = array('Servers Table',	
 "CREATE TABLE `servers` (
 	`id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+	`publicaddress` varchar(100) NOT NULL default '',
 	`ip` varchar(15) NOT NULL default '',
 	`prefix` varchar(30) NOT NULL default '',
 	`name` varchar(100) default NULL,

--- a/src/ASP/system/database/sql.dbupgrade.php
+++ b/src/ASP/system/database/sql.dbupgrade.php
@@ -141,6 +141,10 @@ $sqlupgrade[] = array('Alter Player Table (Add `hidden` column)', '2.4.0',
 "ALTER TABLE `player`
 	ADD COLUMN `hidden` int(6) unsigned NOT NULL default '0';");
 
+$sqlupgrade[] = array('Alter Player Table (Add `publicaddress` column)', '2.5.0',
+"ALTER TABLE `servers`
+	ADD COLUMN `publicaddress` varchar(100) NOT NULL default '' AFTER `id`;");
+
 $sqlupgrade[] = array('Update Version Table', CODE_VER,
 	"INSERT INTO `_version` VALUES ('". CODE_VER ."', ".time().");");
 


### PR DESCRIPTION
The new `publicaddress` column of the `servers` table may be a DNS or IP address, and is useful for display purposes instead of the `ip` column especially when the `ip` is a private IP.

The ASP `Serverinfo` module table now supports AJAX hydration. The `Set Rcon Data` button of each server is renamed to `Manage`, and now allows editing of the `publicaddress` of a server.