### PR TITLE
Fix (bf2sclone): Write page cache only if `RANKING_REFRESH_TIME > 0`

### DIFF
--- a/src/bf2sclone/functions.inc.php
+++ b/src/bf2sclone/functions.inc.php
@@ -39,7 +39,12 @@ function intToMins($time)
 	return $mins = round($time/60, 0);
 }
 
-/* CHACHING FUNCTIONS */
+/* CACHING FUNCTIONS */
+
+function isCachedEnabled()
+{
+	return RANKING_REFRESH_TIME > 0;
+}
 
 function isCached($id)
 {

--- a/src/bf2sclone/index.php
+++ b/src/bf2sclone/index.php
@@ -128,7 +128,9 @@ if($GO == "0" && $PID)
 		include( TEMPLATE_PATH . 'playerstats.php' );
 
 		// write cache file
-		writeCache($PID, trim($template));
+		if (isCachedEnabled()) {
+			writeCache($PID, trim($template));
+		}
 		$LASTUPDATE = intToTime(0);
 		$NEXTUPDATE = intToTime(RANKING_REFRESH_TIME);
 		$template 	= str_replace('{:LASTUPDATE:}', $LASTUPDATE, $template);
@@ -156,7 +158,9 @@ elseif(strcasecmp($GO, 'currentranking') == 0)
 		include( TEMPLATE_PATH .'current-ranking.php');
 
 		// write cache file
-		writeCache('current-ranking', $template);
+		if (isCachedEnabled()) {
+			writeCache('current-ranking', $template);
+		}
 		$LASTUPDATE = intToTime(0);
 		$NEXTUPDATE = intToTime(RANKING_REFRESH_TIME);
 	}
@@ -257,7 +261,9 @@ elseif(strcasecmp($GO, 'servers') == 0 && !$SID)
 		include( TEMPLATE_PATH .'servers.php');
 
 		// write cache file
-		writeCache('servers', $template);
+		if (isCachedEnabled()) {
+			writeCache('servers', $template);
+		}
 		$LASTUPDATE = intToTime(0);
 		$NEXTUPDATE = intToTime(RANKING_REFRESH_TIME);
 	}
@@ -292,7 +298,9 @@ elseif(strcasecmp($GO, 'servers') == 0 && $SID)
 		include( TEMPLATE_PATH .'server.php');
 
 		// write cache file
-		writeCache("servers-$SID", $template);
+		if (isCachedEnabled()) {
+			writeCache("servers-$SID", $template);
+		}
 		$LASTUPDATE = intToTime(0);
 		$NEXTUPDATE = intToTime(RANKING_REFRESH_TIME);
 	}
@@ -351,7 +359,9 @@ else
 		include( TEMPLATE_PATH .'home.php');
 
 		// write cache file
-		writeCache('home', $template);
+		if (isCachedEnabled()) {
+			writeCache('home', $template);
+		}
 		$LASTUPDATE = intToTime(0);
 		$NEXTUPDATE = intToTime(RANKING_REFRESH_TIME);
 	}


### PR DESCRIPTION
Previously, page cache is always written. However, if `RANKING_REFRESH_TIME` is `0`, page cache does not need to be written.

Now, page cache is written only when `RANKING_REFRESH_TIME > 0`,
