### PR TITLE
Fix (ASP): Fix `docker-entrypoint.sh` not creating a stateless config file

### DIFF
--- a/config/ASP/docker-entrypoint.sh
+++ b/config/ASP/docker-entrypoint.sh
@@ -20,6 +20,7 @@ setup /src/ASP/system/database/backups 1
 CONFIG_FILE=/src/ASP/system/config/config.php
 if [ -f "$CONFIG_FILE" ]; then 
     echo "Removing existing config file"
+    rm -fv "$CONFIG_FILE"
 fi
 echo "Setting up config file"
 php /src/ASP/index.php > /dev/null 


### PR DESCRIPTION
Fixes bug in #157
